### PR TITLE
Update 10.3.3-zhuan-huan-he-guo-lv-xiang-ying-shi-liu.md

### DIFF
--- a/di-10-zhang-reactor-jie-shao/10.3-tong-yong-xiang-ying-shi-cao-zuo-shi-zhan/10.3.3-zhuan-huan-he-guo-lv-xiang-ying-shi-liu.md
+++ b/di-10-zhang-reactor-jie-shao/10.3-tong-yong-xiang-ying-shi-cao-zuo-shi-zhan/10.3.3-zhuan-huan-he-guo-lv-xiang-ying-shi-liu.md
@@ -274,7 +274,7 @@ Flux<List<List>> bufferedFlux = fruitFlux.buffer();
 
 ![&#x56FE; 10.19 collect-list &#x64CD;&#x4F5C;&#x4EA7;&#x751F;&#x4E00;&#x4E2A; Mono&#xFF0C;&#x5176;&#x4E2D;&#x5305;&#x542B;&#x7531;&#x4F20;&#x5165; Flux &#x53D1;&#x51FA;&#x7684;&#x6240;&#x6709;&#x6D88;&#x606F;&#x7684;&#x5217;&#x8868;](../../.gitbook/assets/10.19.png)
 
-collectList\(\) 生成一个发布 List 的 Mono，而不是生成一个发布 List 的 Mono。以下测试方法说明了如何使用它：
+collectList\(\) 生成一个发布 List 的 Mono，而不是生成一个发布 List 的 Flux。以下测试方法说明了如何使用它：
 
 ```java
 @Test


### PR DESCRIPTION
更正翻译错误。Rather than produce a Flux that publishes a List, collectList() produces a Mono that publishes a List. -> "collectList\(\) 生成一个发布 List 的 Mono，而不是生成一个发布 List 的 Flux。"